### PR TITLE
Save & Load distraction state

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ This is a packaged version of the `distracting_control` suite from *Stone et al*
 ```bash
 pip install distracting_control
 ```
+You also need to download [the DAVIS 2017 dataset](https://davischallenge.org/davis2017/code.html). Make sure to select the 2017 TrainVal - Images and Annotations (480p). The training images will be used as distracting backgrounds.
+The dataset is assumed to be at `$HOME/datasets/DAVIS`.
 
 Then in your python script:
 

--- a/distracting_control/__init__.py
+++ b/distracting_control/__init__.py
@@ -8,7 +8,7 @@ def make_env(flatten_obs=True, from_pixels=False, frame_skip=1, max_episode_step
     from distracting_control.gym_env import DistractingEnv
     env = DistractingEnv(from_pixels=from_pixels, frame_skip=frame_skip, **kwargs)
     if from_pixels:
-        from gym_dmc.wrappers import ObservationByKey
+        from .wrappers import ObservationByKey
         env = ObservationByKey(env, "pixels")
     elif flatten_obs:
         from gym.wrappers import FlattenObservation

--- a/distracting_control/__init__.py
+++ b/distracting_control/__init__.py
@@ -19,7 +19,7 @@ def make_env(flatten_obs=True, from_pixels=False, frame_skip=1, max_episode_step
     return TimeLimit(env, max_episode_steps=max_episode_steps)
 
 
-for difficulty in [None, 'easy', 'medium', 'hard']:
+for difficulty in ['easy', 'medium', 'hard']:
     for domain_name, task_name in ALL_TASKS:
         suffix = difficulty + '-v1' if difficulty else 'v1'
         ID = f'{domain_name.capitalize()}-{task_name}-{suffix}'

--- a/distracting_control/__init__.py
+++ b/distracting_control/__init__.py
@@ -2,11 +2,13 @@ from dm_control.suite import ALL_TASKS
 from gym.envs import register
 
 
-def make_env(flatten_obs=True, from_pixels=False, frame_skip=1, max_episode_steps=1000, **kwargs):
+def make_env(flatten_obs=True, from_pixels=False, frame_skip=1, max_episode_steps=1000, distracting_seed=0, **kwargs):
     max_episode_steps /= frame_skip
 
     from distracting_control.gym_env import DistractingEnv
-    env = DistractingEnv(from_pixels=from_pixels, frame_skip=frame_skip, **kwargs)
+    seed_kwargs = {key: {'seed': distracting_seed} for key in ('background_kwargs', 'camera_kwargs', 'color_kwargs')}
+    env = DistractingEnv(
+        from_pixels=from_pixels, frame_skip=frame_skip, **seed_kwargs, **kwargs)
     if from_pixels:
         from .wrappers import ObservationByKey
         env = ObservationByKey(env, "pixels")
@@ -21,11 +23,16 @@ for difficulty in [None, 'easy', 'medium', 'hard']:
     for domain_name, task_name in ALL_TASKS:
         suffix = difficulty + '-v1' if difficulty else 'v1'
         ID = f'{domain_name.capitalize()}-{task_name}-{suffix}'
+        if difficulty:
+            distraction_types=('background', 'camera', 'color')
+        else:
+            distraction_types=None
         register(id=ID,
                  entry_point='distracting_control:make_env',
                  kwargs=dict(domain_name=domain_name,
                              task_name=task_name,
                              difficulty=difficulty,
+                             distraction_types=distraction_types,
                              channels_first=True,
                              width=84,
                              height=84,

--- a/distracting_control/__init__.py
+++ b/distracting_control/__init__.py
@@ -17,9 +17,10 @@ def make_env(flatten_obs=True, from_pixels=False, frame_skip=1, max_episode_step
     return TimeLimit(env, max_episode_steps=max_episode_steps)
 
 
-for difficulty in ['easy', 'medium', 'hard']:
+for difficulty in [None, 'easy', 'medium', 'hard']:
     for domain_name, task_name in ALL_TASKS:
-        ID = f'{domain_name.capitalize()}-{task_name}-{difficulty}-v1'
+        suffix = difficulty + '-v1' if difficulty else 'v1'
+        ID = f'{domain_name.capitalize()}-{task_name}-{suffix}'
         register(id=ID,
                  entry_point='distracting_control:make_env',
                  kwargs=dict(domain_name=domain_name,

--- a/distracting_control/__init__.py
+++ b/distracting_control/__init__.py
@@ -17,9 +17,9 @@ def make_env(flatten_obs=True, from_pixels=False, frame_skip=1, max_episode_step
     return TimeLimit(env, max_episode_steps=max_episode_steps)
 
 
-for difficulty in ['easy', 'medium', 'hard']:
+for difficulty in [None, 'easy', 'medium', 'hard']:
     for domain_name, task_name in ALL_TASKS:
-        ID = f'{domain_name.capitalize()}-{task_name}-{difficulty}-v1'
+        ID = f'{domain_name.capitalize()}-{task_name}-{difficulty if difficulty else ""}-v1'
         register(id=ID,
                  entry_point='distracting_control:make_env',
                  kwargs=dict(domain_name=domain_name,

--- a/distracting_control/background.py
+++ b/distracting_control/background.py
@@ -89,7 +89,8 @@ class DistractingBackgroundEnv(control.Environment):
                  num_videos=None,
                  dynamic=False,
                  seed=None,
-                 shuffle_buffer_size=None):
+                 shuffle_buffer_size=None,
+                 fix_background=False):
 
         if not 0 <= video_alpha <= 1:
             raise ValueError('`video_alpha` must be in the range [0, 1]')
@@ -102,6 +103,8 @@ class DistractingBackgroundEnv(control.Environment):
         self._shuffle_buffer_size = shuffle_buffer_size
         self._background = None
         self._current_img_index = 0
+        self._fix_background = fix_background
+        self._seed = seed
 
         if not dataset_path or num_videos == 0:
             # Allow running the wrapper without backgrounds to still set the ground
@@ -135,7 +138,16 @@ class DistractingBackgroundEnv(control.Environment):
     def reset(self):
         """Reset the background state."""
         time_step = self._env.reset()
-        self._reset_background()
+        if self._background is None or not self._fix_background:
+            self._reset_background()
+
+        if self._dynamic and self._fix_background:
+            assert self._background is not None
+            # Reset video idx and direction
+            self._current_img_index = 0
+            self._step_direction = 1
+            self._apply()
+
         return time_step
 
     def _reset_background(self):
@@ -204,7 +216,7 @@ class DistractingBackgroundEnv(control.Environment):
     def step(self, action):
         time_step = self._env.step(action)
 
-        if time_step.first():
+        if time_step.first() and not self._fix_background:
             self._reset_background()
             return time_step
 

--- a/distracting_control/camera.py
+++ b/distracting_control/camera.py
@@ -20,6 +20,8 @@ import copy
 import numpy as np
 from dm_control.rl import control
 
+from .mixins import GetStateMixin
+
 CAMERA_MODES = ['fixed', 'track', 'trackcom', 'targetbody', 'targetbodycom']
 
 
@@ -157,7 +159,7 @@ def get_lookat_point(physics, camera_id):
     return rotated_vec + physics.named.data.cam_xpos[camera_id]
 
 
-class DistractingCameraEnv(control.Environment):
+class DistractingCameraEnv(control.Environment, GetStateMixin):
     """Environment wrapper for camera pose visual distraction.
 
     **NOTE**: This wrapper should be applied BEFORE the pixel wrapper to make sure
@@ -355,3 +357,27 @@ class DistractingCameraEnv(control.Environment):
             return getattr(self._env, attr)
         raise AttributeError("'{}' object has no attribute '{}'".format(
             type(self).__name__, attr))
+
+    @classmethod
+    def from_dict(cls, env, state):
+
+        # Instantiate the class in whatever way and set attributes
+        instance = cls(env,
+                       state['_camera_id'],
+                       state['_horizontal_delta'],
+                       state['_vertical_delta'],
+                       state['_max_vel'],
+                       state['_vel_std'],
+                       state['_roll_delta'],
+                       state['_max_roll_vel'],
+                       state['_roll_vel_std'],
+                       state['_max_zoom_in_percent'],
+                       state['_max_zoom_out_percent'],
+                       )
+        for key, val in state.items():
+            setattr(instance, key, val)
+
+        instance.setup_camera()
+
+        assert instance._fix_camera
+        return instance

--- a/distracting_control/camera.py
+++ b/distracting_control/camera.py
@@ -377,7 +377,5 @@ class DistractingCameraEnv(control.Environment, GetStateMixin):
         for key, val in state.items():
             setattr(instance, key, val)
 
-        instance.setup_camera()
-
         assert instance._fix_camera
         return instance

--- a/distracting_control/color.py
+++ b/distracting_control/color.py
@@ -27,7 +27,7 @@ class DistractingColorEnv(control.Environment):
     the color changes are applied before rendering occurs.
     """
 
-    def __init__(self, env, step_std, max_delta, seed=None):
+    def __init__(self, env, step_std, max_delta, fix_color=False, seed=None):
         """Initialize the environment wrapper.
 
         Args:
@@ -41,18 +41,21 @@ class DistractingColorEnv(control.Environment):
         self._env = env
         self._step_std = step_std
         self._max_delta = max_delta
-        self._random_state = np.random.RandomState()
+        self._random_state = np.random.RandomState(seed=seed)
 
         self._cam_type = None
         self._current_rgb = None
         self._max_rgb = None
         self._min_rgb = None
         self._original_rgb = None
+        self._fix_color = fix_color
+        self._seed = seed
 
     def reset(self):
         """Reset the distractions state."""
         time_step = self._env.reset()
-        self._reset_color()
+        if self._original_rgb is None or not self._fix_color:
+            self._reset_color()
         return time_step
 
     def _reset_color(self):
@@ -73,7 +76,7 @@ class DistractingColorEnv(control.Environment):
     def step(self, action):
         time_step = self._env.step(action)
 
-        if time_step.first():
+        if time_step.first() and not self._fix_color:
             self._reset_color()
             return time_step
 

--- a/distracting_control/gym_env.py
+++ b/distracting_control/gym_env.py
@@ -161,12 +161,13 @@ class DistractingEnv(gym.Env):
 
     def step(self, action):
         reward = 0
-
+        discount = 1
         for i in range(self.frame_skip):
             ts = self.env.step(action)
             if self.non_newtonian:  # zero velocity if non newtonian
                 self.env.physics.data.qvel[:] = 0
             reward += ts.reward or 0
+            discount *= ts.discount
             done = ts.last()
             if done:
                 break

--- a/distracting_control/gym_env.py
+++ b/distracting_control/gym_env.py
@@ -45,6 +45,7 @@ class DistractingEnv(gym.Env):
                  domain_name,
                  task_name,
                  difficulty,
+                 distraction_types,
                  dynamic=False,
                  background_data_path=None,
                  background_kwargs=None,
@@ -69,6 +70,9 @@ class DistractingEnv(gym.Env):
                  no_gravity=False,
                  non_newtonian=False,
                  skip_start=None,  # useful in Manipulator for letting things settle
+
+                 distraction_dict=None,
+                 fix_distraction=False
                  ):
         """
 
@@ -95,6 +99,7 @@ class DistractingEnv(gym.Env):
         :param no_gravity:
         :param non_newtonian:
         :param skip_start:
+        :param fix_distraction:
         """
 
         self.render_kwargs = dict(
@@ -109,6 +114,7 @@ class DistractingEnv(gym.Env):
                               dynamic=dynamic,
 
                               # distractor kwargs
+                              distraction_types=distraction_types,
                               background_dataset_path=background_data_path,
                               background_dataset_videos=background_dataset_videos,
                               background_kwargs=background_kwargs,
@@ -123,6 +129,8 @@ class DistractingEnv(gym.Env):
                               render_kwargs=self.render_kwargs,
                               from_pixels=from_pixels,
                               pixels_observation_key=pixels_observation_key,
+
+                              fix_distraction=fix_distraction,
                               )
         self.pixels_observation_key = pixels_observation_key
         self.metadata = {'render.modes': ['human', 'rgb_array'],

--- a/distracting_control/mixins.py
+++ b/distracting_control/mixins.py
@@ -1,0 +1,6 @@
+class GetStateMixin:
+    def get_distracting_state(self):
+        # Get all public attributes in a class except for _env
+        state = {key:val for key, val in vars(self).items() if not callable(getattr(self, key)) and not key.startswith('__')}
+        state.pop('_env')
+        return state

--- a/distracting_control/suite.py
+++ b/distracting_control/suite.py
@@ -22,6 +22,7 @@ used in the original paper. Each distraction wrapper can be used independently
 though.
 """
 import os
+from copy import deepcopy
 
 try:
     from dm_control import suite  # pylint: disable=g-import-not-at-top
@@ -106,6 +107,7 @@ def load(domain_name,
 
     distraction_types = distraction_types or ()
     distraction_dict = distraction_dict or {}
+    distraction_dict = deepcopy(distraction_dict)
     render_kwargs = render_kwargs or {}
     if "camera_id" not in render_kwargs:
         render_kwargs["camera_id"] = 2 if domain_name == "quadruped" else 0

--- a/distracting_control/suite.py
+++ b/distracting_control/suite.py
@@ -58,6 +58,7 @@ def load(domain_name,
          from_pixels=True,
          pixels_only=True,
          pixels_observation_key="pixels",
+         distraction_dict=None,
          fix_distraction=False):
     """Returns an environment from a domain name, task name and optional settings.
 
@@ -104,6 +105,7 @@ def load(domain_name,
         raise ValueError("Difficulty should be one of: 'easy', 'medium', 'hard'.")
 
     distraction_types = distraction_types or ()
+    distraction_dict = distraction_dict or {}
     render_kwargs = render_kwargs or {}
     if "camera_id" not in render_kwargs:
         render_kwargs["camera_id"] = 2 if domain_name == "quadruped" else 0
@@ -111,8 +113,13 @@ def load(domain_name,
     env = suite.load(domain_name, task_name, task_kwargs=task_kwargs, environment_kwargs=environment_kwargs,
                      visualize_reward=visualize_reward)
 
-    # Apply background distractions.
-    if difficulty or background_kwargs:
+    saved_background = distraction_dict.get('DistractingBackgroundEnv', None)
+    if saved_background:
+        print('loading from saved_background')
+        env = background.DistractingBackgroundEnv.from_dict(env, saved_background)
+    elif 'background' in distraction_types and (difficulty or background_kwargs):
+        # Apply background distractions.
+
         background_dataset_path = (background_dataset_path or BG_DATA_PATH)
         final_background_kwargs = dict(fix_background=fix_distraction)
         if difficulty:
@@ -134,7 +141,11 @@ def load(domain_name,
         env = background.DistractingBackgroundEnv(env, **final_background_kwargs)
 
     # Apply camera distractions.
-    if difficulty or camera_kwargs:
+    saved_camera = distraction_dict.get('DistractingCameraEnv', None)
+    if saved_camera:
+        print('loading saved camera distraction')
+        env = camera.DistractingCameraEnv.from_dict(env, saved_camera)
+    elif 'camera' in distraction_types and (difficulty or camera_kwargs):
         final_camera_kwargs = dict(
             camera_id=render_kwargs["camera_id"],
             fix_camera=fix_distraction
@@ -149,7 +160,11 @@ def load(domain_name,
         env = camera.DistractingCameraEnv(env, **final_camera_kwargs)
 
     # Apply color distractions.
-    if difficulty or color_kwargs:
+    saved_color = distraction_dict.get('DistractingColorEnv', None)
+    if saved_color:
+        print('loading saved color distraction')
+        env = color.DistractingColorEnv.from_dict(env, saved_color)
+    elif 'color' in distraction_types and (difficulty or color_kwargs):
         final_color_kwargs = dict(fix_color=fix_distraction)
         if difficulty:
             # Get kwargs for the given difficulty.

--- a/distracting_control/suite.py
+++ b/distracting_control/suite.py
@@ -44,6 +44,7 @@ def is_available():
 def load(domain_name,
          task_name,
          difficulty=None,
+         distraction_types=None,
          dynamic=False,
          background_dataset_path=None,
          background_dataset_videos="train",
@@ -56,7 +57,8 @@ def load(domain_name,
          render_kwargs=None,
          from_pixels=True,
          pixels_only=True,
-         pixels_observation_key="pixels"):
+         pixels_observation_key="pixels",
+         fix_distraction=False):
     """Returns an environment from a domain name, task name and optional settings.
 
     ```python
@@ -101,6 +103,7 @@ def load(domain_name,
     if difficulty not in [None, "easy", "medium", "hard"]:
         raise ValueError("Difficulty should be one of: 'easy', 'medium', 'hard'.")
 
+    distraction_types = distraction_types or ()
     render_kwargs = render_kwargs or {}
     if "camera_id" not in render_kwargs:
         render_kwargs["camera_id"] = 2 if domain_name == "quadruped" else 0
@@ -111,7 +114,7 @@ def load(domain_name,
     # Apply background distractions.
     if difficulty or background_kwargs:
         background_dataset_path = (background_dataset_path or BG_DATA_PATH)
-        final_background_kwargs = dict()
+        final_background_kwargs = dict(fix_background=fix_distraction)
         if difficulty:
             # Get kwargs for the given difficulty.
             num_videos = suite_utils.DIFFICULTY_NUM_VIDEOS[difficulty]
@@ -132,7 +135,10 @@ def load(domain_name,
 
     # Apply camera distractions.
     if difficulty or camera_kwargs:
-        final_camera_kwargs = dict(camera_id=render_kwargs["camera_id"])
+        final_camera_kwargs = dict(
+            camera_id=render_kwargs["camera_id"],
+            fix_camera=fix_distraction
+        )
         if difficulty:
             # Get kwargs for the given difficulty.
             scale = suite_utils.DIFFICULTY_SCALE[difficulty]
@@ -144,7 +150,7 @@ def load(domain_name,
 
     # Apply color distractions.
     if difficulty or color_kwargs:
-        final_color_kwargs = dict()
+        final_color_kwargs = dict(fix_color=fix_distraction)
         if difficulty:
             # Get kwargs for the given difficulty.
             scale = suite_utils.DIFFICULTY_SCALE[difficulty]

--- a/distracting_control/wrappers.py
+++ b/distracting_control/wrappers.py
@@ -1,0 +1,14 @@
+import gym.spaces as spaces
+from gym import ObservationWrapper
+
+
+class ObservationByKey(ObservationWrapper):
+    r"""Observation wrapper that flattens the observation."""
+
+    def __init__(self, env, obs_key):
+        super().__init__(env)
+        self.obs_key = obs_key
+        self.observation_space = env.observation_space[obs_key]
+
+    def observation(self, observation):
+        return observation[self.obs_key]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 dm-control
-gym-dmc
 # dm-control==0.0.322773188
 # absl-py>=0.9.0
 # numpy>=1.18.3

--- a/specs/gym_dc_demo.py
+++ b/specs/gym_dc_demo.py
@@ -17,10 +17,10 @@ if __name__ == '__main__':
             ('reacher', 'easy'),
             ('walker', 'walk')
         ]:
-            env = gym.make(f'distracting_control:{domain.capitalize()}-{task}-v1', difficulty=difficulty)
+            env = gym.make(f'distracting_control:{domain.capitalize()}-{task}-{difficulty}-v1', from_pixels=True)
 
             obs = env.reset()
             act = env.action_space.sample()
             obs, reward, done, info = env.step(act)
 
-            logger.save_image(obs['pixels'], f"figures/{domain}-{task}-({difficulty}).png")
+            logger.save_image(obs, f"figures/{domain}-{task}-({difficulty}).png")

--- a/specs/gym_dc_test.py
+++ b/specs/gym_dc_test.py
@@ -1,0 +1,74 @@
+"""A simple demo that produces an image from the environment."""
+import os
+from ml_logger import logger
+import numpy as np
+
+import gym
+import distracting_control
+
+if __name__ == '__main__':
+    org_ml_logger_root = os.environ.get('ML_LOGGER_ROOT')
+    os.environ['ML_LOGGER_ROOT'] = ''
+
+    for i, difficulty in enumerate(['easy', 'medium', 'hard']):
+        for domain, task in [
+            ('ball_in_cup', 'catch'),
+            # ('cartpole', 'swingup'),
+            # ('cheetah', 'run'),
+            # ('finger', 'spin'),
+            # ('reacher', 'easy'),
+            # ('walker', 'walk')
+        ]:
+            # NOTE:
+            # f'{domain.capitalize()}-{task}-{difficulty}-v1' loads a distracting env
+            # f'{domain.capitalize()}-{task}-v1' loads a non-distracting env
+            env = gym.make(f'{domain.capitalize()}-{task}-{difficulty}-v1', distracting_seed=0,
+                           from_pixels=True, channels_first=False, dynamic=False, fix_distraction=True)
+
+            prefix = f"reprod_figures/fix_distraction/{domain}-{task}-{difficulty}"
+            n_trials = 5
+            episode_length = 10
+            for j in range(n_trials):
+                obs = env.reset()
+                done = False
+                counter = 0
+                for k in range(episode_length):
+                    print(i, j, k)
+                    logger.save_image(obs, os.path.join(prefix, f"ep{j}-{k}.png"))
+                    act = env.action_space.sample()
+                    obs, reward, done, info = env.step(act)
+                    if done:
+                        break
+
+
+            mock_env = gym.make(f'{domain.capitalize()}-{task}-{difficulty}-v1', distracting_seed=1,
+                           from_pixels=True, channels_first=False, dynamic=False, fix_distraction=True)
+            obs = mock_env.reset()
+
+            prefix = f"reprod_figures/save_and_load/{domain}-{task}-{difficulty}"
+            logger.save_image(obs, os.path.join(prefix, "original_obs.png"))
+
+            _state = mock_env.get_distracting_state()
+
+            import torch
+            os.makedirs(prefix, exist_ok=True)
+            with open(os.path.join(prefix, 'pickled_state.pkl'), 'wb') as f:
+                torch.save(_state, f)
+            print('loading from pickle..')
+            with open(os.path.join(prefix, 'pickled_state.pkl'), 'rb') as f:
+                state = torch.load(f)
+
+            # logger.save_torch(_state, os.path.join(prefix, "pickled_state.pkl"))
+            # state = logger.load_torch(os.path.join(prefix, "pickled_state.pkl"))
+
+            n_trials = 5
+            for j in range(n_trials):
+                # Load distractions from the pickled state
+                # NOTE: distracting_seed should be disregarded
+                env = gym.make(f'{domain.capitalize()}-{task}-{difficulty}-v1', distracting_seed=j * 100,
+                            from_pixels=True, channels_first=False, dynamic=False, fix_distraction=True,
+                            distraction_dict=state)
+                obs = env.reset()
+                logger.save_image(obs, os.path.join(prefix, f"{j}.png"))
+
+    os.environ['ML_LOGGER_ROOT'] = org_ml_logger_root


### PR DESCRIPTION
The only last 5 commits are relevant to the title.
Other commits should have been included in other PRs (including #1 and #2).

Summary (of the last 5 commits):
- remove dependency on gym-dmc
- set distraction_types to change the type of distractions
- set distracting_seed
- save & load distraction state

You can try save & load functionality with `specs/gym_dc_test.py` script.
This should generate `reprod_figures/save_and_load/ball_in_cup-catch-(easy|medium|hard)/*.png`.
You can see that the distractions in the same directory are identical.

Also in `reprod_figures/fix_distraction/ball_in_cup-catch-(easy|medium|hard)/*.png`,
you can see that the distractions are identical across episodes.