### PR TITLE
Support "intensity" mode where a user can specify intensity value.

### DIFF
--- a/distracting_control/__init__.py
+++ b/distracting_control/__init__.py
@@ -2,13 +2,13 @@ from dm_control.suite import ALL_TASKS
 from gym.envs import register
 
 
-def make_env(flatten_obs=True, from_pixels=False, frame_skip=1, max_episode_steps=1000, distraction_seed=0, **kwargs):
+def make_env(flatten_obs=True, from_pixels=False, frame_skip=1, max_episode_steps=1000, **kwargs):
     max_episode_steps /= frame_skip
 
     from distracting_control.gym_env import DistractingEnv
-    seed_kwargs = {key: {'seed': distraction_seed} for key in ('background_kwargs', 'camera_kwargs', 'color_kwargs')}
+
     env = DistractingEnv(
-        from_pixels=from_pixels, frame_skip=frame_skip, **seed_kwargs, **kwargs)
+        from_pixels=from_pixels, frame_skip=frame_skip, **kwargs)
     if from_pixels:
         from .wrappers import ObservationByKey
         env = ObservationByKey(env, "pixels")
@@ -19,15 +19,17 @@ def make_env(flatten_obs=True, from_pixels=False, frame_skip=1, max_episode_step
     return TimeLimit(env, max_episode_steps=max_episode_steps)
 
 
-for difficulty in ['easy', 'medium', 'hard']:
+for difficulty in ['easy', 'medium', 'hard', 'intensity']:
     for domain_name, task_name in ALL_TASKS:
         ID = f'{domain_name.capitalize()}-{task_name}-{difficulty}-v1'
         register(id=ID,
                  entry_point='distracting_control:make_env',
                  kwargs=dict(domain_name=domain_name,
                              task_name=task_name,
-                             difficulty=difficulty,
+                             difficulty=None if difficulty == 'intensity' else difficulty,
+                             intensity=None,
                              distraction_types=('background', 'camera', 'color'),
+                             sample_from_edge=False,
                              channels_first=True,
                              width=84,
                              height=84,

--- a/distracting_control/__init__.py
+++ b/distracting_control/__init__.py
@@ -2,10 +2,12 @@ from dm_control.suite import ALL_TASKS
 from gym.envs import register
 
 
-def make_env(flatten_obs=True, from_pixels=False, frame_skip=1, max_episode_steps=1000, **kwargs):
+def make_env(flatten_obs=True, from_pixels=False, frame_skip=1, max_episode_steps=1000, disable_zoom=False, **kwargs):
     max_episode_steps /= frame_skip
 
     from distracting_control.gym_env import DistractingEnv
+
+    kwargs.update({'camera_kwargs': {'disable_zoom': disable_zoom}})
 
     env = DistractingEnv(
         from_pixels=from_pixels, frame_skip=frame_skip, **kwargs)

--- a/distracting_control/__init__.py
+++ b/distracting_control/__init__.py
@@ -2,12 +2,10 @@ from dm_control.suite import ALL_TASKS
 from gym.envs import register
 
 
-def make_env(flatten_obs=True, from_pixels=False, frame_skip=1, max_episode_steps=1000, disable_zoom=False, **kwargs):
+def make_env(flatten_obs=True, from_pixels=False, frame_skip=1, max_episode_steps=1000, **kwargs):
     max_episode_steps /= frame_skip
 
     from distracting_control.gym_env import DistractingEnv
-
-    kwargs.update({'camera_kwargs': {'disable_zoom': disable_zoom}})
 
     env = DistractingEnv(
         from_pixels=from_pixels, frame_skip=frame_skip, **kwargs)

--- a/distracting_control/gym_env.py
+++ b/distracting_control/gym_env.py
@@ -59,6 +59,7 @@ class DistractingEnv(gym.Env):
                  color_kwargs=None,
                  task_kwargs=None,
                  environment_kwargs=None,
+                 disable_zoom=False,
                  visualize_reward=False,
                  pixels_observation_key="pixels",
 
@@ -130,6 +131,7 @@ class DistractingEnv(gym.Env):
                               background_kwargs=background_kwargs,
                               camera_kwargs=camera_kwargs,
                               color_kwargs=color_kwargs,
+                              disable_zoom=disable_zoom,
 
                               # original
                               task_kwargs=task_kwargs,

--- a/distracting_control/gym_env.py
+++ b/distracting_control/gym_env.py
@@ -45,7 +45,9 @@ class DistractingEnv(gym.Env):
                  domain_name,
                  task_name,
                  difficulty,
+                 intensity,
                  distraction_types,
+                 sample_from_edge=False,
                  dynamic=False,
                  background_data_path=None,
                  background_kwargs=None,
@@ -72,13 +74,15 @@ class DistractingEnv(gym.Env):
                  skip_start=None,  # useful in Manipulator for letting things settle
 
                  distraction_dict=None,
-                 fix_distraction=False
+                 fix_distraction=False,
+                 distraction_seed=0
                  ):
         """
 
         :param domain_name:
         :param task_name:
         :param difficulty:
+        :param intensity:
         :param dynamic:
         :param background_data_path:
         :param background_kwargs:
@@ -103,6 +107,9 @@ class DistractingEnv(gym.Env):
         :param fix_distraction:
         """
 
+        assert not (intensity is not None and difficulty), "You can only use one of difficulty levels or specify intensity manually." \
+            + f" But not both.\nintensity: {intensity}\tdifficulty: {difficulty}"
+
         self.render_kwargs = dict(
             height=height,
             width=width,
@@ -112,10 +119,12 @@ class DistractingEnv(gym.Env):
         self.env = suite.load(domain_name,
                               task_name,
                               difficulty,
+                              intensity,
                               dynamic=dynamic,
 
                               # distractor kwargs
                               distraction_types=distraction_types,
+                              sample_from_edge=sample_from_edge,
                               background_dataset_path=background_data_path,
                               background_dataset_videos=background_dataset_videos,
                               background_kwargs=background_kwargs,
@@ -133,6 +142,7 @@ class DistractingEnv(gym.Env):
 
                               fix_distraction=fix_distraction,
                               distraction_dict=distraction_dict,
+                              distraction_seed=distraction_seed,
                               )
         self.pixels_observation_key = pixels_observation_key
         self.metadata = {'render.modes': ['human', 'rgb_array'],

--- a/distracting_control/suite.py
+++ b/distracting_control/suite.py
@@ -148,6 +148,8 @@ def load(domain_name,
 
     # Apply camera distractions.
     saved_camera = distraction_dict.get('DistractingCameraEnv', None)
+    # NOTE: it's important to remove the entry with pop, since non-empty camera_kwargs triggers DistractingCameraEnv.
+    disable_zoom = camera_kwargs.pop('disable_zoom', False)
     if saved_camera:
         print('loading saved camera distraction')
         env = camera.DistractingCameraEnv.from_dict(env, saved_camera)
@@ -160,7 +162,7 @@ def load(domain_name,
         if difficulty or intensity:
             # Get kwargs for the given difficulty.
             scale = suite_utils.DIFFICULTY_SCALE[difficulty] if difficulty else intensity
-            final_camera_kwargs.update(suite_utils.get_camera_kwargs(domain_name, scale, dynamic))
+            final_camera_kwargs.update(suite_utils.get_camera_kwargs(domain_name, scale, dynamic, disable_zoom))
         if camera_kwargs:
             # Overwrite kwargs with those passed here.
             final_camera_kwargs.update(camera_kwargs)

--- a/distracting_control/suite.py
+++ b/distracting_control/suite.py
@@ -55,6 +55,7 @@ def load(domain_name,
          camera_kwargs=None,
          color_kwargs=None,
          task_kwargs=None,
+         disable_zoom=False,
          environment_kwargs=None,
          visualize_reward=False,
          render_kwargs=None,
@@ -123,7 +124,6 @@ def load(domain_name,
         print('loading from saved_background')
         env = background.DistractingBackgroundEnv.from_dict(env, saved_background)
     elif 'background' in distraction_types and (difficulty or background_kwargs):
-        assert intensity is None, "intensity keyword is not supported for background distraction!"
         # Apply background distractions.
 
         background_dataset_path = (background_dataset_path or BG_DATA_PATH)
@@ -149,7 +149,6 @@ def load(domain_name,
     # Apply camera distractions.
     saved_camera = distraction_dict.get('DistractingCameraEnv', None)
     # NOTE: it's important to remove the entry with pop, since non-empty camera_kwargs triggers DistractingCameraEnv.
-    disable_zoom = camera_kwargs.pop('disable_zoom', False)
     if saved_camera:
         print('loading saved camera distraction')
         env = camera.DistractingCameraEnv.from_dict(env, saved_camera)

--- a/distracting_control/suite_utils.py
+++ b/distracting_control/suite_utils.py
@@ -76,3 +76,12 @@ def get_background_kwargs(domain_name,
         dataset_videos=dataset_videos,
         shuffle_buffer_size=100 if shuffle else None,
     )
+
+
+def sample(random_state, low=0.0, high=1.0, size=None, distribution='uniform'):
+    if distribution == 'uniform':
+        return random_state.uniform(low, high, size)
+    elif distribution == 'edge':
+        return random_state.choice([low, high], size=size)
+    else:
+        ValueError('Only uniform and edge are supported right now')

--- a/distracting_control/suite_utils.py
+++ b/distracting_control/suite_utils.py
@@ -34,7 +34,7 @@ def get_color_kwargs(scale, dynamic):
     return dict(max_delta=max_delta, step_std=step_std)
 
 
-def get_camera_kwargs(domain_name, scale, dynamic):
+def get_camera_kwargs(domain_name, scale, dynamic, disable_zoom=False):
     # assert domain_name in ['reacher', 'cartpole', 'finger', 'cheetah', 'ball_in_cup', 'walker']
     assert 0.0 <= scale <= 1.0, f"scale needs to be in [0, 1]. Currently {scale}."
     return dict(
@@ -46,8 +46,8 @@ def get_camera_kwargs(domain_name, scale, dynamic):
         max_vel=.4 * scale if dynamic else 0.,
         roll_std=np.pi / 300 * scale if dynamic else 0.,
         max_roll_vel=np.pi / 50 * scale if dynamic else 0.,
-        max_zoom_in_percent=.5 * scale,
-        max_zoom_out_percent=1.5 * scale,
+        max_zoom_in_percent=.5 * scale if not disable_zoom else 0.0,
+        max_zoom_out_percent=1.5 * scale if not disable_zoom else 0.0,
         limit_to_upper_quadrant='reacher' not in domain_name,
     )
 

--- a/specs/gym_dc-intensity-demo.py
+++ b/specs/gym_dc-intensity-demo.py
@@ -1,0 +1,91 @@
+"""A simple demo that produces an image from the environment."""
+import os
+from ml_logger import logger
+import numpy as np
+
+import gym
+import distracting_control
+import time
+
+class Time:
+    accm_saveimg = 0
+    accm_step = 0
+    accm_reset = 0
+
+from contextlib import contextmanager
+
+@contextmanager
+def mllogger_root_to(value=''):
+    org_ml_logger_root = os.environ.get('ML_LOGGER_ROOT', "")
+    os.environ['ML_LOGGER_ROOT'] = value
+    try:
+        yield
+    finally:
+        os.environ['ML_LOGGER_ROOT'] = org_ml_logger_root
+
+
+def compile_images(outdir='reprod_figures/intensities'):
+    with mllogger_root_to():
+        intensities = np.linspace(0, 1, 10 + 1)
+        for distraction in ['color', 'camera']:
+            for domain, task in [
+                ('ball_in_cup', 'catch'),
+                ('cartpole', 'swingup'),
+                ('cheetah', 'run'),
+                ('finger', 'spin'),
+                ('reacher', 'easy'),
+                ('walker', 'walk')
+            ]:
+                prefix = f"{outdir}/{distraction}/{domain}-{task}"
+                observations = []
+                for i, intensity in enumerate(intensities):
+                    print(distraction, prefix, intensity)
+
+                    env = gym.make(
+                        f'distracting_control:{domain.capitalize()}-{task}-intensity-v1',
+                        from_pixels=True, channels_first=False, dynamic=False, fix_distraction=True,
+                        intensity=intensity, distraction_types=(distraction,), sample_from_edge=True
+                    )
+                    env.reset()
+                    observations.append(env.unwrapped.env.physics.render(height=128, width=128, camera_id=0))
+
+                logger.save_image(np.hstack(observations), prefix + "-intensities.png")
+
+
+def record_video(outdir='reprod_figures/intensities/video'):
+    with mllogger_root_to():
+        domain, task = 'cheetah', 'run'
+        intensity = 0.3
+        for distraction in ['color', 'camera']:
+            for distr_seed in [val * 100 for val in range(5)]:
+                prefix = f"{outdir}/{distraction}/{domain}-{task}-intensity{intensity}-seed{distr_seed}"
+                n_trials = 5
+                episode_length = 10
+                for j in range(n_trials):
+                    print(prefix, j)
+
+                    env = gym.make(
+                        f'distracting_control:{domain.capitalize()}-{task}-intensity-v1',
+                        from_pixels=True, channels_first=False, dynamic=False, fix_distraction=True,
+                        intensity=intensity, distraction_types=(distraction, ), sample_from_edge=True,
+                        distraction_seed=distr_seed
+                    )
+                    obs = env.reset()
+
+                    done = False
+                    frames = []
+                    for k in range(episode_length):
+                        frames.append(env.unwrapped.env.physics.render(height=256, width=256, camera_id=0))
+                        act = env.action_space.sample()
+                        obs, reward, done, info = env.step(act)
+                        if done:
+                            break
+
+                    logger.save_video(frames, prefix + f'ep{j}.mp4')
+
+
+if __name__ == '__main__':
+    print("---------- genrating images ----------")
+    compile_images()
+    print("---------- genrating videos ----------")
+    record_video()


### PR DESCRIPTION
If sample_from_edge=True is set altogether, it always samples from an
edge of uniform distribution defined by the intensity.

For example, a user can use this mode with:
```python
domain, task = 'cheetah', 'run'
distraction = 'camera'
env = gym.make(
    f'distracting_control:{domain.capitalize()}-{task}-intensity-v1',
    dynamic=False, fix_distraction=True,
    intensity=0.3, distraction_types=(distraction, ), sample_from_edge=True
)
```
More examples and demo code is available at specs/gym_dc-intensity-demo.py