### PR TITLE
Fix converting of gym spec for images

### DIFF
--- a/distracting_control/gym_env.py
+++ b/distracting_control/gym_env.py
@@ -14,7 +14,10 @@ def convert_dm_control_to_gym_space(dm_control_space, **kwargs):
                            dtype=dm_control_space.dtype)
         assert space.shape == dm_control_space.shape
         return space
-    elif isinstance(dm_control_space, specs.Array) and not isinstance(dm_control_space, specs.BoundedArray):
+    elif isinstance(dm_control_space, specs.Array):
+        if dm_control_space.dtype == np.uint8:
+            # Image
+            return spaces.Box(low=0, high=255, shape=dm_control_space.shape, dtype=dm_control_space.dtype)
         space = spaces.Box(low=-float('inf'),
                            high=float('inf'),
                            shape=dm_control_space.shape,

--- a/distracting_control/gym_env.py
+++ b/distracting_control/gym_env.py
@@ -14,7 +14,7 @@ def convert_dm_control_to_gym_space(dm_control_space, **kwargs):
                            dtype=dm_control_space.dtype)
         assert space.shape == dm_control_space.shape
         return space
-    elif isinstance(dm_control_space, specs.Array):
+    elif isinstance(dm_control_space, specs.Array) and not isinstance(dm_control_space, specs.BoundedArray):
         # In case this is an image
         # if isinstance(dm_control_space, specs.BoundedArray):
         if dm_control_space.dtype == np.uint8:

--- a/distracting_control/gym_env.py
+++ b/distracting_control/gym_env.py
@@ -15,21 +15,23 @@ def convert_dm_control_to_gym_space(dm_control_space, **kwargs):
         assert space.shape == dm_control_space.shape
         return space
     elif isinstance(dm_control_space, specs.Array):
+        # In case this is an image
+        # if isinstance(dm_control_space, specs.BoundedArray):
         if dm_control_space.dtype == np.uint8:
-            # Image
-            return spaces.Box(low=0, high=255, shape=dm_control_space.shape, dtype=dm_control_space.dtype)
-        space = spaces.Box(low=-float('inf'),
-                           high=float('inf'),
-                           shape=dm_control_space.shape,
-                           dtype=dm_control_space.dtype)
-        return space
+            return spaces.Box(low=0,
+                              high=255,
+                              shape=dm_control_space.shape,
+                              dtype=dm_control_space.dtype)
+        return spaces.Box(low=-float('inf'),
+                          high=float('inf'),
+                          shape=dm_control_space.shape,
+                          dtype=dm_control_space.dtype)
     elif isinstance(dm_control_space, dict):
         kwargs.update(
             {key: convert_dm_control_to_gym_space(value)
              for key, value in dm_control_space.items()}
         )
-        space = spaces.Dict(kwargs)
-        return space
+        return spaces.Dict(kwargs)
 
 
 def extract_min_max(s):
@@ -111,8 +113,9 @@ class DistractingEnv(gym.Env):
         :param fix_distraction:
         """
 
-        assert not (intensity is not None and difficulty), "You can only use one of difficulty levels or specify intensity manually." \
-            + f" But not both.\nintensity: {intensity}\tdifficulty: {difficulty}"
+        assert not (
+                intensity is not None and difficulty), "You can only use one of difficulty levels or specify intensity manually." \
+                                                       + f" But not both.\nintensity: {intensity}\tdifficulty: {difficulty}"
 
         self.render_kwargs = dict(
             height=height,
@@ -276,7 +279,6 @@ class DistractingEnv(gym.Env):
         """Go through the child classes by recursively visting ._env property,
         and call save_state() method if it's either of background ,color, camera env.
         """
-        import os
         from .background import DistractingBackgroundEnv
         from .camera import DistractingCameraEnv
         from .color import DistractingColorEnv


### PR DESCRIPTION
I had issues with the automatic conversion of specs to gym spaces when the space is an image of dtype 'uint8'.
This could be due to dependency version, but should be a reasonable fix in all cases.